### PR TITLE
Fix: Block restricted fields in /users/me updates to prevent privilege escalation (#5)

### DIFF
--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -251,8 +251,21 @@ async def verify_email(user_id: UUID, token: str, db: AsyncSession = Depends(get
     raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired verification token")
 
 @router.patch("/users/me", response_model=UserResponse)
-async def update_me(user_update: UserUpdate, db: AsyncSession = Depends(get_db), current_user: User = Depends(get_current_user)):
+async def update_me(
+    user_update: UserUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
     update_data = user_update.dict(exclude_unset=True)
+
+    # Block sensitive fields before setting
+    restricted_fields = {
+        "is_professional", "role", "email_verified",
+        "verification_token", "failed_login_attempts",
+        "last_login_at", "professional_status_updated_at"
+    }
+    for field in restricted_fields:
+        update_data.pop(field, None)
 
     for field, value in update_data.items():
         setattr(current_user, field, value)


### PR DESCRIPTION
This PR addresses [Issue #5](https://github.com/pengwingokla/user_management/issues/5), where regular users could update restricted fields (e.g., is_professional, role, etc.) via the /users/me endpoint.

**What’s fixed:**
Sensitive fields are now explicitly removed from the incoming update payload before applying changes:

`is_professional`
`role`
`email_verified`
`verification_token`
`failed_login_attempts`
`last_login_at`
`professional_status_updated_at`

**Expected behavior:**
Regular users cannot escalate privileges or alter protected metadata via self-update.
Only editable fields (like name, bio, profile URLs) remain updatable.